### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dasug/stne-log-parser/security/code-scanning/1](https://github.com/Dasug/stne-log-parser/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/node.js.yml` at the workflow root level (after `on:` and before `jobs:`), setting only the minimum needed for this CI workflow.  
For the current steps (`actions/checkout`, setup node, install, test), `contents: read` is sufficient and preserves existing functionality.

Concretely:
- File: `.github/workflows/node.js.yml`
- Region: between lines 10 and 12 in the provided snippet
- Change: insert
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
